### PR TITLE
Manage cage dinosaurs count in model

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The source code is based on the [Rails API Boilerplate](https://github.com/shftc
 Some [requirements](#business-requirements) which were not mentioned in the assignment are addressed below. The code can be easily refactored if the requirements changes.
 
 * Use UUID for record IDs in order to avoid vulnerability attacks
-* A cage has a unique tag name and location
+* A cage has a unique tag name and a non-unique location
 * A cage cannot be deleted when it contains dinosaurs, i.e. not empty.
 * A cage max capacity cannot be changed, it can only be set on create
 * The max capacity of a cage is set to 100 for validation purposes. It's a constant variable and can easily make it configurable if it needs to

--- a/app/models/dinosaur.rb
+++ b/app/models/dinosaur.rb
@@ -20,10 +20,6 @@ class Dinosaur < ApplicationRecord
 
   private
 
-  def update_dinosaurs_count
-    cage&.update_dinosaurs_count
-  end
-
   def update_diet
     return unless species_changed?
 

--- a/app/models/dinosaur.rb
+++ b/app/models/dinosaur.rb
@@ -3,10 +3,7 @@
 require './app/lib/park'
 
 class Dinosaur < ApplicationRecord
-  # NOTE: attempted to use counter_cache but cage.dinosaurs_count becomes -1
-  # When moving dinosaur from the "from" cage containing just this dinosaur.
-  # Expected the count = 0, but not -1; even from_cage.dinosaurs.size returns -1
-  # belongs_to :cage #, counter_cache: true
+  # NOTE: Could not use counter_cache, need association callbacks to be fired
   belongs_to :cage, optional: true
 
   before_save :update_diet

--- a/app/services/dinosaurs/delete_service.rb
+++ b/app/services/dinosaurs/delete_service.rb
@@ -6,9 +6,18 @@ module Dinosaurs
 
     def call
       dinosaur = Dinosaur.find(params[:id])
-      dinosaur.destroy
 
-      Success()
+      ActiveRecord::Base.transaction(requires_new: true) do
+        cage = dinosaur.cage
+        if cage.present?
+          cage.dinosaurs&.delete(dinosaur)
+          return resource_failure(cage) unless cage.save
+        end
+
+        dinosaur.destroy
+
+        Success()
+      end
     rescue StandardError
       resource_failure(dinosaur)
     end

--- a/app/swagger_docs/controllers/v1/cages_controller.rb
+++ b/app/swagger_docs/controllers/v1/cages_controller.rb
@@ -141,7 +141,7 @@ module Controllers
       # GET /v1/cages/{id}
       swagger_path '/v1/cages/{id}' do
         operation :get do
-          key :summary, 'Show cage'
+          key :summary, 'Show cage with a filter option'
           key :description, 'Show the cage details'
           key :operationId, 'cageShow'
           key :tags, [

--- a/test/controllers/v1/dinosaurs_controller_test.rb
+++ b/test/controllers/v1/dinosaurs_controller_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 module V1
   class DinosaursControllerTest < ActionDispatch::IntegrationTest
-    attr_reader :params, :doorkeeper_application
+    attr_reader :params, :cage, :dinosaur, :doorkeeper_application
 
     setup do
       @cage = create(:cage)
@@ -22,7 +22,7 @@ module V1
 
     test 'should get dinosaurs filtered by species' do
       params[:query] = {
-        species_eq: @params[:species]
+        species_eq: params[:species]
       }
       get v1_dinosaurs_url, params:, as: :json
 
@@ -49,15 +49,23 @@ module V1
     end
 
     test 'should update dinosaur' do
-      patch v1_dinosaur_update_url(@dinosaur), params:, as: :json
+      patch v1_dinosaur_update_url(dinosaur), params:, as: :json
       assert_response :success
     end
 
     test 'should destroy dinosaur' do
+      dinosaur.cage = cage
+      cage.dinosaurs_count = 1
+      cage.save
+      dinosaur.save
+
       assert_difference('Dinosaur.count', -1) do
-        delete v1_dinosaur_url(@dinosaur), params:, as: :json
+        delete v1_dinosaur_url(dinosaur), params:, as: :json
       end
 
+      cage.reload
+
+      assert_equal 0, cage.dinosaurs_count
       assert_response :success
     end
   end

--- a/test/services/dinosaurs/delete_service_test.rb
+++ b/test/services/dinosaurs/delete_service_test.rb
@@ -4,18 +4,34 @@ require 'test_helper'
 
 module Dinosaurs
   class DeleteServiceTest < ActiveSupport::TestCase
-    attr_reader :params, :cage, :doorkeeper_application
+    attr_reader :params, :cage, :dinosaur, :doorkeeper_application
 
     def setup
-      @dinosaur = create(:dinosaur)
+      @cage = create(:cage, power_status: :active, dinosaurs_count: 1)
+      @dinosaur = create(:dinosaur, cage: @cage)
       @doorkeeper_application = create(:doorkeeper_application)
     end
 
-    test 'should delete cage successfully' do
-      params = { id: @dinosaur.id }
+    test 'should delete dinosaur when not contained (not in a cage) successfully' do
+      dinosaur = create(:dinosaur)
+      params = { id: dinosaur.id }
 
       assert_difference 'Dinosaur.count', -1 do
         service = Dinosaurs::DeleteService.new(params:, doorkeeper_application:).call
+
+        assert service.success?
+      end
+    end
+
+    test 'should delete dinosaur when contained in a cage successfully' do
+      params = { id: dinosaur.id }
+
+      assert_difference 'Dinosaur.count', -1 do
+        service = Dinosaurs::DeleteService.new(params:, doorkeeper_application:).call
+
+        assert_equal 1, cage.dinosaurs_count
+        cage.reload
+        assert_equal 0, cage.dinosaurs_count
 
         assert service.success?
       end


### PR DESCRIPTION
Avoid doing expensive DB dinosaurs count on every cage save.

Handle the count on the model. Protect from going under 0. It has happened at times when invoking unit tests very quickly.